### PR TITLE
[suggestion] Use details tag to showing image and video

### DIFF
--- a/src/models/html.ts
+++ b/src/models/html.ts
@@ -221,7 +221,9 @@ export default class HTMLFormatter {
                 }
             }
             // not video, use image
-            return this.createUpdatableLink('<img src="' + value.media_url_https + size + '"/>', this.imagePrefix + encodeURIComponent(value.media_url_https + ':large'));
+            var linkImage = this.createUpdatableLink('<img src="' + value.media_url_https + size + '"/>', this.imagePrefix + encodeURIComponent(value.media_url_https + ':large'));
+            var imgUrl = '<details><summary>' + value.media_url_https + '</summary>' + linkImage + '</details>';
+            return imgUrl;
         }).join(' ');
         if (mediaStr != '') {
             result += '<p>' + mediaStr + '</p>';

--- a/src/models/html.ts
+++ b/src/models/html.ts
@@ -210,19 +210,19 @@ export default class HTMLFormatter {
                 const control = ((value.type == 'animated_gif') ? this.autoplayControl : this.videoControl);
                 const variants: any[] = value.video_info.variants;
                 if (variants.length != 0) {
-                    mediaStr += '<video width="340" poster="' + value.media_url_https + '" ' + control + '>';
+                    mediaStr += '<details><summary>[video]</summary><video width="340" poster="' + value.media_url_https + '" ' + control + '>';
                     variants.filter((video, index, array) => { 
                         return (video.content_type as string).startsWith("video"); 
                     }).forEach((video, index, array) => {
                         mediaStr += '<source src="' + video.url + '" type="' + video.content_type + '"/>';
                     });
-                    mediaStr += '</video>';
+                    mediaStr += '</video></details>';
                     return mediaStr;
                 }
             }
             // not video, use image
             var linkImage = this.createUpdatableLink('<img src="' + value.media_url_https + size + '"/>', this.imagePrefix + encodeURIComponent(value.media_url_https + ':large'));
-            var imgUrl = '<details><summary>' + value.media_url_https + '</summary>' + linkImage + '</details>';
+            var imgUrl = '<details><summary>[image]</summary>' + linkImage + '</details>';
             return imgUrl;
         }).join(' ');
         if (mediaStr != '') {


### PR DESCRIPTION
I would like to show images and video with details tag in this client like following.

<img width="604" alt="folding images" src="https://user-images.githubusercontent.com/3255509/40585564-2a597214-61f0-11e8-95a1-569d6469a472.png">

<img width="1006" alt="expand folding" src="https://user-images.githubusercontent.com/3255509/40585572-46c43646-61f0-11e8-917f-ae6c44f1d770.png">
